### PR TITLE
sync carts between pages

### DIFF
--- a/src/javaScript/indexDom.js
+++ b/src/javaScript/indexDom.js
@@ -91,6 +91,8 @@ document.addEventListener('DOMContentLoaded', () => {
       populateGamesHighlights(allGames, mainHighlightContainer)
       addCountCart()
     })
+
+  displayCartItemsOnMainPage()
 })
 
 function populateGamesContainer (payload, gamesContainer) {
@@ -247,6 +249,8 @@ export function addGameToCart (cartContainer, title, price, imgSrc) {
     cartContainer.appendChild(gameCartElement)
   }
 
+  displayCartItemsOnMainPage()
+
   return true
 }
 
@@ -276,4 +280,36 @@ function addCountCart () {
       }
     })
   })
+}
+
+function displayCartItemsOnMainPage () {
+  const cartContainer = document.querySelector('#game-items-container')
+  const cartCountElement = document.querySelector('#cart-count')
+  const cartItems = JSON.parse(localStorage.getItem('cart')) || []
+
+  cartContainer.innerHTML = ''
+  let totalCount = 0
+
+  cartItems.forEach((item) => {
+    totalCount += item.quantity
+
+    const gameCartElement = document.createElement('div')
+    gameCartElement.classList.add('game-item')
+    gameCartElement.dataset.title = item.name
+
+    gameCartElement.innerHTML = `
+      <div class="flex flex-1 justify-between text-center items-center gap-5 p-4 w-auto">
+        <img src="${item.imgSrc}" alt="Game cover" class="h-20 w-20 rounded-full">
+        <span><strong>${item.name}</strong></span>
+        <div class="flex justify-end gap-5">
+          <span>${item.price}</span>
+          <span class="game-count dark-button text-center w-6 h-6 ring-1">${item.quantity}</span>
+        </div>
+      </div>
+    `
+
+    cartContainer.appendChild(gameCartElement)
+  })
+
+  updateCartCount(cartCountElement, totalCount)
 }

--- a/src/javaScript/indexDom.js
+++ b/src/javaScript/indexDom.js
@@ -196,6 +196,47 @@ function updateCartCount (cartCountElement, count) {
 
 const gameCounts = {}
 
+function addCountCart () {
+  let totalCount = 0
+  const cartButtons = document.querySelectorAll('.add-to-cart')
+  const cartContainer = document.querySelector('#game-items-container')
+  const cartCountElement = document.querySelector('#cart-count')
+
+  cartButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const gameContainer = button.closest('.game-container')
+      if (!gameContainer) {
+        return
+      }
+
+      const title = gameContainer.querySelector('[data-name]')?.innerText
+      const price = gameContainer.querySelector('[data-price]')?.innerText
+      const imgSrc = gameContainer.querySelector('[data-img]')?.src
+
+      if (title && price && imgSrc) {
+        const added = addGameToCart(cartContainer, title, price, imgSrc)
+        if (added) {
+          totalCount++
+          updateCartCount(cartCountElement, totalCount)
+        }
+      }
+    })
+  })
+}
+
+function generateCartItemHTML (item) {
+  return `
+    <div class="flex flex-1 justify-between text-center items-center gap-5 p-4 w-auto">
+      <img src="${item.imgSrc}" alt="Game cover" class="h-20 w-20 rounded-full">
+      <span><strong>${item.name}</strong></span>
+      <div class="flex justify-end gap-5">
+        <span>${item.price}</span>
+        <span class="game-count dark-button text-center w-6 h-6 ring-1">${item.quantity}</span>
+      </div>
+    </div>
+  `
+}
+
 export function addGameToCart (cartContainer, title, price, imgSrc) {
   if (!cartContainer) return false
 
@@ -235,16 +276,12 @@ export function addGameToCart (cartContainer, title, price, imgSrc) {
     gameCartElement.classList.add('game-item')
     gameCartElement.dataset.title = title
 
-    gameCartElement.innerHTML = `
-      <div class="flex flex-1 justify-between text-center items-center gap-5 p-4 w-auto"> 
-        <img src="${imgSrc}" alt="Game cover" class="h-20 w-20 rounded-full"> 
-        <span><strong>${title}</strong></span>
-        <div class="flex justify-end gap-5">
-        <span>${price}</span>
-        <span class="game-count dark-button text-center w-6 h-6 ring-1">${gameCounts[title]}</span>
-        </div>
-      </div>
-    `
+    gameCartElement.innerHTML = generateCartItemHTML({
+      name: title,
+      price,
+      imgSrc,
+      quantity: gameCounts[title]
+    })
 
     cartContainer.appendChild(gameCartElement)
   }
@@ -252,34 +289,6 @@ export function addGameToCart (cartContainer, title, price, imgSrc) {
   displayCartItemsOnMainPage()
 
   return true
-}
-
-function addCountCart () {
-  let totalCount = 0
-  const cartButtons = document.querySelectorAll('.add-to-cart')
-  const cartContainer = document.querySelector('#game-items-container')
-  const cartCountElement = document.querySelector('#cart-count')
-
-  cartButtons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const gameContainer = button.closest('.game-container')
-      if (!gameContainer) {
-        return
-      }
-
-      const title = gameContainer.querySelector('[data-name]')?.innerText
-      const price = gameContainer.querySelector('[data-price]')?.innerText
-      const imgSrc = gameContainer.querySelector('[data-img]')?.src
-
-      if (title && price && imgSrc) {
-        const added = addGameToCart(cartContainer, title, price, imgSrc)
-        if (added) {
-          totalCount++
-          updateCartCount(cartCountElement, totalCount)
-        }
-      }
-    })
-  })
 }
 
 function displayCartItemsOnMainPage () {
@@ -297,16 +306,7 @@ function displayCartItemsOnMainPage () {
     gameCartElement.classList.add('game-item')
     gameCartElement.dataset.title = item.name
 
-    gameCartElement.innerHTML = `
-      <div class="flex flex-1 justify-between text-center items-center gap-5 p-4 w-auto">
-        <img src="${item.imgSrc}" alt="Game cover" class="h-20 w-20 rounded-full">
-        <span><strong>${item.name}</strong></span>
-        <div class="flex justify-end gap-5">
-          <span>${item.price}</span>
-          <span class="game-count dark-button text-center w-6 h-6 ring-1">${item.quantity}</span>
-        </div>
-      </div>
-    `
+    gameCartElement.innerHTML = generateCartItemHTML(item)
 
     cartContainer.appendChild(gameCartElement)
   })


### PR DESCRIPTION
# PR 14-07-24
## Overview
In this PR we sync the carts between the main page and the checkout page
## Key Changes :
 1) indexDom.js : 
    - Implementing the function `displayCartItemsOnMainPage` that allow us to see the same game that we have in the checkout page and if user make any change on the checkout page we are going to see this changes applied on the main page cart aswell 

![Animation](https://github.com/user-attachments/assets/1fdb266b-272c-4555-8f66-607ce799d236)
